### PR TITLE
[Refactor] 디자인 토큰들을 import 하기 쉬운 형태 export를 수정합니다

### DIFF
--- a/src/styles/index.ts
+++ b/src/styles/index.ts
@@ -3,7 +3,7 @@ import { padding } from './token/padding';
 import { font } from './token/font';
 import { border } from './token/border';
 
-export const styles = {
+export {
   padding,
   font,
   border,

--- a/src/styles/index.ts
+++ b/src/styles/index.ts
@@ -1,11 +1,4 @@
-import { colors } from './token/colors';
-import { padding } from './token/padding';
-import { font } from './token/font';
-import { border } from './token/border';
-
-export {
-  padding,
-  font,
-  border,
-  colors,
-};
+export { colors } from './token/colors';
+export { padding } from './token/padding';
+export { font } from './token/font';
+export { border } from './token/border';


### PR DESCRIPTION
## ➕ 이슈 링크

- 이슈 넘버 #27

## 🔎 작업 내용

- 디자인 토큰 export 하는 형태를 import해서 사용하기 편한 형태로 수정했습니다.
- 전 작업 #22  

## 👀 수정 전 후 비교

- fefore
```typescript
// styles.ts

import { colors } from './token/colors';
import { padding } from './token/padding';
import { font } from './token/font';
import { border } from './token/border';

export const styles = {
  padding,
  font,
  border,
  colors,
};

```

```typescript
import { styles } from "./styles";

const {
  padding,
  font,
  border,
  colors,
} = styles;
```

- after
```typescript
// styles.ts

export { colors } from './token/colors';
export { padding } from './token/padding';
export { font } from './token/font';
export { border } from './token/border';
```

```typescript
import { padding, font, border, colors } from "./styles";
```
```typescript
import { colors } from "./styles";
```

## 🔧 리뷰 요구사항

- 리뷰 요구사항을 작성해주세요
