### PR TITLE
[Refactor] 회원가입 페이지, 로그인 페이지를 묶는 디렉토리 생성 및 파일 구조 수정합니다

### DIFF
--- a/src/pages/Login/LogInForm.tsx
+++ b/src/pages/Login/LogInForm.tsx
@@ -1,5 +1,0 @@
-function LogInForm() {
-  return <h1>로그인 컴포넌트입니다.</h1>;
-}
-
-export default LogInForm;

--- a/src/pages/Login/index.tsx
+++ b/src/pages/Login/index.tsx
@@ -1,4 +1,0 @@
-function Login() {
-  return <h1>로그인 페이지입니다.</h1>;
-}
-export default Login;

--- a/src/pages/index.ts
+++ b/src/pages/index.ts
@@ -1,3 +1,5 @@
+import { Login, SignUp } from './sign';
+import { EmployeeList, SalaryRequest } from './admin';
 import {
   UserHome,
   Schedule,
@@ -6,9 +8,7 @@ import {
   SalaryCorrection,
   SalaryDetails,
 } from './user';
-import { EmployeeList, SalaryRequest } from './admin';
-import { default as Login } from './Login';
-import { default as SignUp } from './SignUp';
+
 export {
   UserHome,
   Login,

--- a/src/pages/index.ts
+++ b/src/pages/index.ts
@@ -1,6 +1,6 @@
-import { Login, SignUp } from './sign';
-import { EmployeeList, SalaryRequest } from './admin';
-import {
+export { Login, SignUp } from './sign';
+export { EmployeeList, SalaryRequest } from './admin';
+export {
   UserHome,
   Schedule,
   EditProfile,
@@ -8,16 +8,3 @@ import {
   SalaryCorrection,
   SalaryDetails,
 } from './user';
-
-export {
-  UserHome,
-  Login,
-  SignUp,
-  Schedule,
-  EditProfile,
-  Attendance,
-  EmployeeList,
-  SalaryRequest,
-  SalaryCorrection,
-  SalaryDetails,
-};

--- a/src/pages/sign/Login/LogInForm.tsx
+++ b/src/pages/sign/Login/LogInForm.tsx
@@ -1,0 +1,11 @@
+const LoginForm = () => {
+  return (
+    <div>
+      <input type="email" placeholder="이메일" />
+      <input type="password" placeholder="비밀번호" />
+      <button type="submit">로그인</button>
+    </div>
+  );
+};
+
+export default LoginForm;

--- a/src/pages/sign/Login/index.tsx
+++ b/src/pages/sign/Login/index.tsx
@@ -1,0 +1,12 @@
+import { default as LoginForm } from './LogInForm';
+
+const Login = () => {
+  return (
+    <section>
+      <h1>로그인</h1>
+      <LoginForm />
+    </section>
+  );
+};
+
+export default Login;

--- a/src/pages/sign/SignUp/SignUpForm.tsx
+++ b/src/pages/sign/SignUp/SignUpForm.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 const SignUpForm = () => {
   return <div>SignUpForm</div>;
 };

--- a/src/pages/sign/SignUp/index.tsx
+++ b/src/pages/sign/SignUp/index.tsx
@@ -1,11 +1,12 @@
-import React from 'react';
+import { default as SignUpForm } from './SignUpForm';
 
-function SignUp() {
+const SignUp = () => {
   return (
     <div>
       <h1>회원가입 페이지입니다.</h1>
+      <SignUpForm />
     </div>
   );
-}
+};
 
 export default SignUp;

--- a/src/pages/sign/index.ts
+++ b/src/pages/sign/index.ts
@@ -1,0 +1,2 @@
+export { default as Login } from './Login';
+export { default as SignUp } from './SignUp';

--- a/src/pages/user/index.ts
+++ b/src/pages/user/index.ts
@@ -1,15 +1,6 @@
-import { default as UserHome } from './UserHome';
-import { default as Schedule } from './Schedule';
-import { default as EditProfile } from './EditProfile';
-import { default as Attendance } from './Attendance';
-import { default as SalaryCorrection } from './SalaryCorrection';
-import { default as SalaryDetails } from './SalaryDetails';
-
-export {
-  UserHome,
-  Schedule,
-  EditProfile,
-  Attendance,
-  SalaryCorrection,
-  SalaryDetails,
-};
+export { default as UserHome } from './UserHome';
+export { default as Schedule } from './Schedule';
+export { default as EditProfile } from './EditProfile';
+export { default as Attendance } from './Attendance';
+export { default as SalaryCorrection } from './SalaryCorrection';
+export { default as SalaryDetails } from './SalaryDetails';


### PR DESCRIPTION
## ➕ 이슈 링크

- 이슈 넘버 #38 

## 🔎 작업 내용

- 전에 논의한 pages/Signup, pages/Login 파일을 pages/sign 디렉토리 하위로 이동하여 그룹화
- pages 배럴 export 구조 수정 (import문과 export문 따로 사용 -> import 키워드 없이 바로 export 사용)

## 💾 참고

- pages/index.ts
```typescript
export { Login, SignUp } from './sign';
```

## 🔧 리뷰 요구사항

- 리뷰 요구사항을 작성해주세요
