### PR TITLE
[Settings] ts 파일에서 css import 경로 에러 메시지가 뜨는 것을 해결합니다

### DIFF
--- a/src/types/style.d.ts
+++ b/src/types/style.d.ts
@@ -1,0 +1,9 @@
+declare module '*.css' {
+  const classes: { [key: string]: string };
+  export default classes;
+}
+
+declare module '*.scss' {
+  const classes: { [key: string]: string };
+  export default classes;
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,6 +15,7 @@
       "@store/*": ["src/state/store/*"],
       "@styles/*": ["src/styles/*"],
       "@types/*": ["src/types/*"]
-    }
+    },
+    "typeRoots": ["./node_modules/@types", "./src/types"]
   }
 }


### PR DESCRIPTION
## ➕ 이슈 링크

- 이슈 넘버 #46 

## 🔎 작업 내용

- typescript가 css 파일을 import 할 때 에러 메시지가 뜨는 이슈를 해결합니다.
- scode 내장 typescript 사용할 때는 인식 문제가 없었으나 프로젝트 내 설치된 typescript을 사용하게 했을 때 나타나는 이슈입니다.
- css, scss 확장자 타입 선언을 선언하여 문제를 해결했습니다.

## 💾 이미지 첨부

- types/style.d.ts

```typescript
declare module '*.css' {
  const classes: { [key: string]: string };
  export default classes;
}

declare module '*.scss' {
  const classes: { [key: string]: string };
  export default classes;
}
```

## 🔧 리뷰 요구사항

**관련 작업**
ISSUE #42 
PR #43 
- 🔧 IDE 가 인식하지 않는 이슈 해결 방법
  3 . Typescript 설정을 VS CODE가 아닌 프로젝트 기준으로 설정 수정


**추가 확인 사항**
> css와 scss 확장자 파일 타입선언 파일을 style.d.ts 파일명으로 만들었는데 이 파일명 때문에 eslint가 잘 작동하지 않아서 lint 실패 후 커밋을 할 수가 없없습니다. 
원래 eslint의 종속성 라이브러리인 `acorn`이 제대로 동작하지 않아 `npm install acorn --save-dev` 명시적으로 설치하여 lint가 돌고 커밋을 할 수 있었습니다. 
`acorn` 설치한 package.json 파일을 pr에 포함하지 않았지만 문제가 지속될 경우 따로 이슈 생성하여 추가하겠습니다.