### PR TITLE
[Feature] fetchDataFromDB 유틸 함수가 반환하는 값의 구조를 변경합니다

### DIFF
--- a/src/firebase/fetchDataFromDB.ts
+++ b/src/firebase/fetchDataFromDB.ts
@@ -1,7 +1,7 @@
 import { ref, get, DatabaseReference } from 'firebase/database';
 import { database } from '../firebaseConfig';
 
-type FetchData<T> = Promise<T | Record<string, T> | null>;
+type FetchData<T> = Promise<T[] | null>;
 
 interface FetchDataParams {
   table: string;
@@ -21,30 +21,28 @@ const fetchDataFromDB = async <T>({
 
     if (snapshot.exists()) {
       const data = snapshot.val();
-      const result = data ? (!key ? Object.values(data) : data) : null;
+      const result = Object.entries(data).map(([key, value]) => {
+        if (typeof value === 'object' && value !== null) {
+          return {
+            id: key,
+            ...value,
+          } as T;
+        }
+        return {
+          id: key,
+          value,
+        } as T;
+      });
 
       return result;
     } else {
       console.warn('데이터가 존재하지 않습니다.');
-
       return null;
     }
   } catch (error) {
     console.error('데이터 가져오기 실패:', error);
-
     throw error;
   }
 };
 
 export { fetchDataFromDB };
-
-/** 사용 방법
- * await fetchDataFromDB({ table, key });
- * ex) await fetchDataFromDB({ 'Users', 'p0qTmHR3PU1LJ3' });
- *
- * 매개변수는 { table, key } 객체 형태
- *
- * table의 값은 firebase realtime database의 collection name이다.
- * key의 값은 collection의 하위 데이터를 분류하는 문서 이름 혹은 null이 들어갈 수 있다. (optional)
- * key를 null로 전달할 경우 'Users'의 모든 데이터를 가져온다. 반환 값 : {} 형태
- */

--- a/src/firebase/fetchDataFromDB.ts
+++ b/src/firebase/fetchDataFromDB.ts
@@ -46,3 +46,14 @@ const fetchDataFromDB = async <T>({
 };
 
 export { fetchDataFromDB };
+
+/** 사용 방법
+ * await fetchDataFromDB({ table, key });
+ * ex) await fetchDataFromDB({ 'Users', 'p0qTmHR3PU1LJ3' });
+ *
+ * 매개변수는 { table, key } 객체 형태
+ *
+ * table의 값은 firebase realtime database의 collection name이다.
+ * key의 값은 collection의 하위 데이터를 분류하는 문서 이름 혹은 null이 들어갈 수 있다. (optional)
+ * key를 null로 전달할 경우 'Users'의 모든 데이터를 가져온다. 반환 값 : {} 형태
+ */


### PR DESCRIPTION
## ➕ 이슈 링크

- 이슈 넘버 #65 

## 🔎 작업 내용

- fetchDataFromDB가 테이블의 key도 함께 반환하도록 구조를 변경합니다.
   - 기존에는 value만 반환했습니다.
- 타입 가드를 이용하고 FetchData<T> 타입을 새로 정의했습니다.

## 💾 이미지 첨부

```javascript
interface ScheduleList {
  createdAt: string;
  detail: string;
  endedAt: string;
  startedAt: string;
  title: string;
  updatedAt: string;
}

interface ScheduleData {
  id: string;
  scheduleList: ScheduleList[];
  userId: string;
}

// 생략

const SCHEDULE_DATA = (await fetchDataFromDB({
        table: 'Schedule',
      })) as ScheduleData[];
```

## 🔧 리뷰 요구사항

- 리뷰 요구사항을 작성해주세요
