### PR TITLE
[Feature/Design] 스케줄 페이지의 디자인과 추가 기능을 구현합니다

### DIFF
--- a/src/components/FileUploading/index.tsx
+++ b/src/components/FileUploading/index.tsx
@@ -8,6 +8,7 @@ import {
 } from 'firebase/storage';
 import { storage } from '../../firebaseConfig';
 import Button from '../form/Button';
+import { border, colors, padding } from '../../styles';
 
 interface FileUploadingProps {
   filePath: string;
@@ -138,7 +139,15 @@ const S = {
     gap: 16px;
   `,
   Input: styled.input`
-    padding: 12px;
+    /* padding: 12px;
+    flex: 1; */
+    width: 100%;
+    height: 51px;
+    line-height: 1;
+    padding: 0 ${padding.md};
+    border: ${border.default};
+    border-radius: ${border.radius.xs};
+    outline-color: ${colors.semantic.hover.primary};
     flex: 1;
   `,
 };

--- a/src/pages/user/Schedule/ScheduleMain/DetailScheduleWrapper/index.tsx
+++ b/src/pages/user/Schedule/ScheduleMain/DetailScheduleWrapper/index.tsx
@@ -84,6 +84,8 @@ const DetailScheduleWrapper = ({
   const formattedDay = String(day).padStart(2, '0');
   const formattedClickedDate = `${year}-${formattedMonth}-${formattedDay}`;
 
+  const currentDate = `${currentTime.getFullYear()}-${currentTime.getMonth() + 1}-${currentTime.getDate()}`;
+
   const filterClickedDateTeamSchedule = (
     startedAt: string,
     endedAt: string
@@ -189,7 +191,9 @@ const DetailScheduleWrapper = ({
           clickedDateTeamScheduleData={clickedDateTeamScheduleData}
           handleRModalOpen={handleRModalOpen}
         />
-        <S.CurrentTimeLine style={{ top: `${TIME_LINE_POSITION}px` }} />
+        {formattedClickedDate === currentDate && (
+          <S.CurrentTimeLine style={{ top: `${TIME_LINE_POSITION}px` }} />
+        )}
       </S.ScheduleContainer>
     </>
   );

--- a/src/pages/user/Schedule/core/ScheduleModal/ScheduleModalContents/index.tsx
+++ b/src/pages/user/Schedule/core/ScheduleModal/ScheduleModalContents/index.tsx
@@ -210,25 +210,29 @@ const ScheduleModalContents = ({
 
   const deleteSchedule = async () => {
     try {
-      setIsLoading(true);
-      const clearScheduleEntry = {
-        title: '',
-        startedAt: '',
-        endedAt: '',
-        detail: '',
-        documentName: '',
-        documentUrl: '',
-        createdAt: '',
-        updatedAt: '',
-      };
+      if (confirm('일정을 삭제하시겠습니까?')) {
+        setIsLoading(true);
+        const clearScheduleEntry = {
+          title: '',
+          startedAt: '',
+          endedAt: '',
+          detail: '',
+          documentName: '',
+          documentUrl: '',
+          createdAt: '',
+          updatedAt: '',
+        };
 
-      await saveDataToDB({
-        table: 'Schedule',
-        key: targetSchedule.id
-          ? `${targetSchedule.id}/scheduleList/${targetSchedule.index}`
-          : '',
-        data: clearScheduleEntry,
-      });
+        console.log(targetSchedule.index);
+
+        await saveDataToDB({
+          table: 'Schedule',
+          key: targetSchedule.id
+            ? `${targetSchedule.id}/scheduleList/${targetSchedule.index}`
+            : '',
+          data: clearScheduleEntry,
+        });
+      }
     } catch (error) {
       console.error('데이터 삭제 중 오류:', error);
     } finally {
@@ -369,7 +373,7 @@ const ScheduleModalContents = ({
         <S.ButtonWrapper>
           <Button color="success" text="수정" onClick={handleEditMode} />
           <Button
-            color={isLoading ? 'disabled' : 'success'}
+            color={isLoading ? 'disabled' : 'danger'}
             text="삭제"
             onClick={deleteSchedule}
           />

--- a/src/pages/user/Schedule/core/ScheduleModal/ScheduleModalContents/index.tsx
+++ b/src/pages/user/Schedule/core/ScheduleModal/ScheduleModalContents/index.tsx
@@ -1,11 +1,12 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { saveDataToDB } from '../../../../../../firebase/saveDataToDB';
 import { fetchDataFromDB } from '../../../../../../firebase/fetchDataFromDB';
 import FileUploading from '../../../../../../components/FileUploading';
 import Button from '../../../../../../components/form/Button';
-import { colors } from '../../../../../../styles';
+import { border, colors, padding } from '../../../../../../styles';
 import { fetchUserInfo } from '../../../../../../firebase';
 import { User } from '../../../../../../types/interface';
+import styled from 'styled-components';
 
 interface ScheduleList {
   createdAt: string;
@@ -247,16 +248,31 @@ const ScheduleModalContents = ({
     setModalType('U');
   };
 
+  const textareaRef = useRef<HTMLTextAreaElement | null>(null);
+
+  const onChangeTextarea = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
+    setDetail(e.target.value);
+
+    if (textareaRef && textareaRef.current) {
+      textareaRef.current.style.height = '0px';
+      const scrollHeight = textareaRef.current.scrollHeight;
+
+      console.log(scrollHeight);
+      textareaRef.current.style.height = scrollHeight + 'px';
+    }
+  };
+
   return (
     <>
       <div style={{ fontSize: '20px', fontWeight: '700' }}>
-        {modalType === 'R'
-          ? `${targetSchedule.name}님의 일정`
-          : '새로운 일정 등록'}
+        {modalType === 'R' && `${targetSchedule.name}님의 일정`}
+        {modalType === 'C' && `새로운 일정 등록`}
+        {modalType === 'U' && `${targetSchedule.name}님의 일정 수정`}
       </div>
 
       <div>제목</div>
-      <input
+      <S.Input
+        modalType={modalType}
         readOnly={modalType === 'R'}
         value={modalType === 'R' ? targetSchedule.title : title}
         onChange={(e) => setTitle(e.target.value)}
@@ -267,14 +283,16 @@ const ScheduleModalContents = ({
         {titleError}
       </div>
       <div>시작 시간</div>
-      <input
+      <S.Input
+        modalType={modalType}
         readOnly={modalType === 'R'}
         value={modalType === 'R' ? targetSchedule.startedAt : startedAt}
         onChange={(e) => setStartedAt(e.target.value)}
         type="datetime-local"
       />
       <div>종료 시간</div>
-      <input
+      <S.Input
+        modalType={modalType}
         readOnly={modalType === 'R'}
         value={modalType === 'R' ? targetSchedule.endedAt : endedAt}
         onChange={(e) => setEndedAt(e.target.value)}
@@ -285,8 +303,16 @@ const ScheduleModalContents = ({
       </div>
       <div>첨부 파일</div>
 
-      {targetSchedule.documentName ? (
-        <div>{targetSchedule.documentName}</div>
+      {modalType === 'R' ? (
+        <S.Input
+          modalType={modalType}
+          value={
+            targetSchedule.documentName
+              ? targetSchedule.documentName
+              : '첨부파일이 없습니다'
+          }
+          readOnly
+        />
       ) : (
         <FileUploading
           filePath="schedule-doc"
@@ -295,14 +321,16 @@ const ScheduleModalContents = ({
         />
       )}
       <div>내용</div>
-      <textarea
+      <S.Textarea
+        modalType={modalType}
         readOnly={modalType === 'R'}
         value={modalType === 'R' ? targetSchedule.detail : detail}
-        onChange={(e) => setDetail(e.target.value)}
+        onChange={onChangeTextarea}
         name="content"
         id=""
         placeholder="일정 내용"
-      ></textarea>
+        ref={textareaRef}
+      ></S.Textarea>
       <div style={{ color: colors.semantic.danger, fontSize: '12px' }}>
         {detailError}
       </div>
@@ -310,16 +338,55 @@ const ScheduleModalContents = ({
         <Button color="success" text="등록" onClick={editSchedule} />
       )}
       {modalType === 'R' && (
-        <div>
+        <S.ButtonWrapper>
           <Button color="success" text="수정" onClick={handleEditMode} />
           <Button color="danger" text="삭제" onClick={deleteSchedule} />
-        </div>
+        </S.ButtonWrapper>
       )}
       {modalType === 'U' && (
-        <Button color="success" text="등록" onClick={editSchedule} />
+        <Button color="success" text="수정" onClick={editSchedule} />
       )}
     </>
   );
+};
+
+const S = {
+  Input: styled.input<{ modalType: ModalType }>`
+    width: 100%;
+    height: 40px;
+    line-height: 1;
+    padding: 0 ${padding.md};
+    border: ${border.default};
+    border-radius: ${border.radius.xs};
+
+    ${(props) =>
+      props.modalType === 'R'
+        ? `background-color: ${colors.scale.neutral.s95};
+          outline: none
+          `
+        : `outline-color: ${colors.semantic.hover.primary};`}
+  `,
+  Textarea: styled.textarea<{ modalType: ModalType }>`
+    width: 100%;
+    min-height: 104px;
+    max-height: 176px;
+    line-height: 1;
+    padding: ${padding.md};
+    border: ${border.default};
+    border-radius: ${border.radius.xs};
+    resize: none;
+
+    ${(props) =>
+      props.modalType === 'R'
+        ? `background-color: ${colors.scale.neutral.s95};
+          outline: none
+          `
+        : `outline-color: ${colors.semantic.hover.primary};`}
+  `,
+  ButtonWrapper: styled.button`
+    display: flex;
+    justify-content: space-between;
+  `,
 };
 
 export default ScheduleModalContents;

--- a/src/pages/user/Schedule/core/ScheduleModal/ScheduleModalContents/index.tsx
+++ b/src/pages/user/Schedule/core/ScheduleModal/ScheduleModalContents/index.tsx
@@ -261,6 +261,15 @@ const ScheduleModalContents = ({
     }
   };
 
+  const handleFileDownload = (fileUrl: string, fileName: string) => {
+    const link = document.createElement('a');
+    link.href = fileUrl;
+    link.download = fileName;
+    document.body.appendChild(link);
+    link.click();
+    document.body.removeChild(link);
+  };
+
   return (
     <>
       <div style={{ fontSize: '20px', fontWeight: '700' }}>
@@ -302,13 +311,21 @@ const ScheduleModalContents = ({
       </div>
       <div>첨부 파일</div>
 
-      {modalType === 'R' ? (
+      {modalType === 'R' || modalType === 'U' ? (
         <S.Input
+          documentName={targetSchedule.documentName}
           modalType={modalType}
           value={
             targetSchedule.documentName
               ? targetSchedule.documentName
               : '첨부파일이 없습니다'
+          }
+          onClick={() =>
+            targetSchedule.documentName &&
+            handleFileDownload(
+              targetSchedule.documentUrl,
+              targetSchedule.documentName
+            )
           }
           readOnly
         />
@@ -363,7 +380,7 @@ const ScheduleModalContents = ({
 };
 
 const S = {
-  Input: styled.input<{ modalType: ModalType }>`
+  Input: styled.input<{ modalType: ModalType; documentName?: string }>`
     width: 100%;
     height: 40px;
     line-height: 1;
@@ -371,12 +388,14 @@ const S = {
     border: ${border.default};
     border-radius: ${border.radius.xs};
 
+    ${(props) => props.documentName && `cursor: pointer;`};
+
     ${(props) =>
-      props.modalType === 'R'
+      props.modalType === 'R' || props.documentName
         ? `background-color: ${colors.scale.neutral.s95};
           outline: none
           `
-        : `outline-color: ${colors.semantic.hover.primary};`}
+        : `outline-color: ${colors.semantic.hover.primary};`};
   `,
   Textarea: styled.textarea<{ modalType: ModalType }>`
     width: 100%;

--- a/src/pages/user/Schedule/core/ScheduleModal/index.tsx
+++ b/src/pages/user/Schedule/core/ScheduleModal/index.tsx
@@ -61,6 +61,7 @@ const ScheduleModal = ({
           targetSchedule={targetSchedule}
           modalType={modalType}
           setModalType={setModalType}
+          handleOnCloseModal={handleOnCloseModal}
         />
       </S.ModalWrapper>
     </S.ModalBackground>

--- a/src/pages/user/Schedule/index.tsx
+++ b/src/pages/user/Schedule/index.tsx
@@ -5,6 +5,8 @@ import ScheduleSideBar from './ScheduleSideBar';
 import { useEffect, useState } from 'react';
 import { fetchDataFromDB } from '../../../firebase/fetchDataFromDB';
 import ScheduleModal from './core/ScheduleModal';
+import { useFetchUserInfo } from '../../../hooks';
+import { Loading } from '../../../components';
 
 interface TeamData {
   id: string;
@@ -74,6 +76,11 @@ const Schedule = () => {
   });
   const [isDayClick, setIsDayClick] = useState(false);
   const [clickedDate, setClickedDate] = useState<number[]>([]);
+  const { userInfo, error, isLoading } = useFetchUserInfo();
+
+  console.log(userInfo);
+
+  console.log(currentSchedule);
 
   const handleYearMonthChange = (year: number, month: number) => {
     setCurrentYear(year);
@@ -85,8 +92,32 @@ const Schedule = () => {
 
     setTeamData(teamsData);
 
+    console.log(teamsData);
+
     return teamsData;
   };
+
+  const getCurrentUserTeamsData = () => {
+    console.log(teamData);
+    console.log(userInfo && userInfo);
+
+    const currentUserTeams = teamData.find((team) =>
+      team.members.some(
+        (member) => userInfo && member.userId === userInfo.userId
+      )
+    )?.members as TeamMembersData[];
+    console.log(currentUserTeams);
+
+    setCurrentSchedule({
+      type: 'team',
+      teamId: currentUserTeams,
+      userId: '',
+    });
+  };
+
+  useEffect(() => {
+    getCurrentUserTeamsData();
+  }, [userInfo]);
 
   const handleCModalOpen = () => {
     setModalType('C');
@@ -102,6 +133,9 @@ const Schedule = () => {
   useEffect(() => {
     getTeamsData();
   }, []);
+
+  if (isLoading) return <Loading />;
+  if (error) return <div>오류 발생: {error.message}</div>;
 
   return (
     <>


### PR DESCRIPTION
## ➕ 이슈 링크

- 이슈 넘버 #62 

## 🔎 작업 내용

- [x] 업무 상세 페이지 디자인 업데이트
- [x] 사이드바의 팀원 이름, 팀원들의 스케줄에 고유 색상을 추가
- [x] 상세 일정 페이지의 타임라인 막대를 금일 상세 일정 페이지에서만 렌더되도록 변경
- [x] 업무 상세 확인 모달에서 파일 이름 클릭 시 다운로드 되도록 구현

## 💾 이미지 첨부

- 스크린샷이나 레퍼런스를 추가해주세요

## 🔧 리뷰 요구사항

- 리뷰 요구사항을 작성해주세요
