### PR TITLE
[Hotfix] merge 이후 로딩 변수 오탈자로 나타나는 렌더링 이슈 해결

### DIFF
--- a/src/pages/user/SalaryCorrectionPage/SalaryCorrectionMain/SalaryCorrectionList/index.tsx
+++ b/src/pages/user/SalaryCorrectionPage/SalaryCorrectionMain/SalaryCorrectionList/index.tsx
@@ -96,7 +96,7 @@ const SalaryCorrectionList = () => {
         </div>
       </S.SalaryLabelContainer>
       <S.SalaryMainContainer>
-        {loading ? (
+        {isLoading ? (
           <div>로딩 중...</div>
         ) : currentPageItems.length > 0 ? (
           currentPageItems.map((item) => (

--- a/src/slices/navigation/actions.ts
+++ b/src/slices/navigation/actions.ts
@@ -1,0 +1,5 @@
+export {
+  setActiveIndex,
+  toggleExpandedSalary,
+  resetSalaryExpansion,
+} from './navigationSlice';

--- a/src/slices/navigation/navigationSlice.ts
+++ b/src/slices/navigation/navigationSlice.ts
@@ -1,0 +1,32 @@
+import { createSlice, PayloadAction } from '@reduxjs/toolkit';
+
+interface NavigationState {
+  activeIndex: number | null;
+  expandedSalary: boolean;
+}
+
+const initialState: NavigationState = {
+  activeIndex: null,
+  expandedSalary: false,
+};
+
+const navigationSlice = createSlice({
+  name: 'navigation',
+  initialState,
+  reducers: {
+    setActiveIndex(state, action: PayloadAction<number | null>) {
+      state.activeIndex = action.payload;
+    },
+    toggleExpandedSalary(state) {
+      state.expandedSalary = !state.expandedSalary;
+    },
+    resetSalaryExpansion(state) {
+      state.expandedSalary = false;
+    },
+  },
+});
+
+export const { setActiveIndex, toggleExpandedSalary, resetSalaryExpansion } =
+  navigationSlice.actions;
+
+export default navigationSlice.reducer;

--- a/src/slices/reducer.ts
+++ b/src/slices/reducer.ts
@@ -1,3 +1,4 @@
 export { default as counterReducer } from './counter/counterSlice';
 export { default as userReducer } from './user/userSlice';
 export { default as paginationReducer } from './pagination/paginationSlice';
+export { default as navigationReducer } from './navigation/navigationSlice';

--- a/src/state/store.ts
+++ b/src/state/store.ts
@@ -3,6 +3,7 @@ import {
   counterReducer,
   userReducer,
   paginationReducer,
+  navigationReducer,
 } from '../slices/reducer';
 
 const store = configureStore({
@@ -10,6 +11,7 @@ const store = configureStore({
     counter: counterReducer,
     user: userReducer,
     pagination: paginationReducer,
+    navigation: navigationReducer,
   },
   devTools: process.env.NODE_ENV !== 'production',
 });


### PR DESCRIPTION
## ➕ 이슈 링크

- 이슈 넘버 #100 

## 🔎 작업 내용

- 로딩 변수 오탈자 수정

## 💾 이미지 첨부

- 스크린샷이나 레퍼런스를 추가해주세요

## 🔧 리뷰 요구사항

아래 이슈를 해결하기 위해  navigation 전역 상태관리자를 생성했지만 시간이 지연되는 거 같아 해당 이슈는 아직 해결하지 않고 먼저 PR 올립니다.

- 로그인 후 첫 집입 시 첫 화면 페이지와 다른 네비게이션 메뉴가 활성화 되는 이슈 수정 
- 머지 과정에서 loading 상태변수 오탈자가 생긴 부분을 수정
