### PR TITLE
[fix] 데이터를 저장하는 saveDataToDB 함수 내 유저 인증 검증 로직을 필수로 실행합니다.

### DIFF
--- a/src/firebase/saveDataToDB.ts
+++ b/src/firebase/saveDataToDB.ts
@@ -7,23 +7,19 @@ interface saveDataParams<T> {
   table: string;
   key?: string;
   data: T;
-  requireAuth?: boolean;
 }
 
 const saveDataToDB = async <T>({
   table,
   key,
   data,
-  requireAuth = false,
 }: saveDataParams<T>): SaveData => {
   try {
-    if (requireAuth) {
-      // 인증 필요 시, 사용자 확인
-      const user = auth.currentUser;
+    // 사용자 검증
+    const user = auth.currentUser;
 
-      if (!user) {
-        throw new Error('인증된 사용자가 아닙니다.');
-      }
+    if (!user) {
+      throw new Error('인증된 사용자가 아닙니다.');
     }
 
     const dbRef = key ? ref(database, `${table}/${key}`) : ref(database, table);

--- a/src/hooks/useSaveData.ts
+++ b/src/hooks/useSaveData.ts
@@ -5,7 +5,6 @@ import { saveDataToDB } from '../firebase';
 interface UseSaveDataParams {
   table: string;
   key?: string;
-  requireAuth?: boolean;
 }
 
 interface UseSaveDataReturn<T> {
@@ -17,7 +16,6 @@ interface UseSaveDataReturn<T> {
 function useSaveData<T>({
   table,
   key,
-  requireAuth = false,
 }: UseSaveDataParams): UseSaveDataReturn<T> {
   const [isSaving, setIsSaving] = useState(false);
   const [error, setError] = useState<Error | null>(null);
@@ -28,7 +26,7 @@ function useSaveData<T>({
 
     try {
       // 1. Firebase 데이터 저장
-      const savedKey = await saveDataToDB({ table, key, data, requireAuth });
+      const savedKey = await saveDataToDB({ table, key, data });
 
       // 2. SWR 캐시 갱신 (로컬 데이터와 서버 데이터 동기화)
       const cacheKey = key ? `${table}/${key}` : table;

--- a/src/pages/user/Profile/ProfileForm.tsx
+++ b/src/pages/user/Profile/ProfileForm.tsx
@@ -11,7 +11,6 @@ const ProfileForm = () => {
   const [formData, setFormData] = useState<FormData>({ name: '', email: '' });
   const { saveData, isSaving, error } = useSaveData<FormData>({
     table: COLLECTION_NAME.users,
-    requireAuth: true, // 인증 여부 필요
   });
 
   const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {


### PR DESCRIPTION
## ➕ 이슈 링크

- 이슈 넘버 #93 

## 🔎 작업 내용

- Realtime Database에 데이터를 저장하는 saveDataToDB 인증 여부 확인 매개변수 requireAuth 의 디폴트 값을 true로 변경하려다가 매개변수로 받지 않고 내부에 필수적으로 실행하도록 변경

## 💾 이미지 첨부

- 스크린샷이나 레퍼런스를 추가해주세요

## 🔧 리뷰 요구사항

- 회원가입 시 사용하는 파이어베이스 SDK가 제공하는 함수는 auth에서 제공하는 함수이므로 saveDataToDB 함수와 관계가 없어서saveDataToDB 함수 내부 로직에 필수로 고정했습니다
